### PR TITLE
Make tests in conda build pass

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,7 @@ test:
   source_files:
     # copy files from source dir into temp test dir necessary for tests to pass
     - tests/*
-    - src/SALib/test_functions/params/Ishigami.txt
-    - src/SALib/test_functions/params/Ishigami_groups.txt
+    - src/*
   imports:
     - SALib
   requires:


### PR DESCRIPTION
Quick fix to make tests pass during conda build process.

Instead of rewriting dependent test data locations I copy the entire package code to the test location created as part of the conda build process.

Ideally tests would be rewritten so as to not rely on hardcoded paths, but I think I will leave that for a later date.